### PR TITLE
fix: Properly manage modal creation for the iframe

### DIFF
--- a/ui-web/sdk/src/index.ts
+++ b/ui-web/sdk/src/index.ts
@@ -9,6 +9,8 @@ export interface TrinsicSessionResult {
   resultsAccessKey?: string;
 }
 
+let isMicroModalInitialized = false;
+
 export async function launchIframe(
   launchUrl: string
 ): Promise<TrinsicSessionResult> {
@@ -17,14 +19,16 @@ export async function launchIframe(
   style.id = "trinsic-ui-style";
   style.textContent = CSSString;
   document.head.appendChild(style);
-  MicroModal.init();
-  if (launchUrl === undefined || launchUrl === null || launchUrl === "") {
+
+  if (!launchUrl) {
     throw new Error(
-      "Please specify a launch url by calling our API via one of our backend SDK's"
+      "Please specify a launch URL by calling our API via one of our backend SDKs"
     );
   }
+
   showModal(launchUrl);
-  var result = new Promise<TrinsicSessionResult>((resolve, reject) => {
+
+  return new Promise<TrinsicSessionResult>((resolve, reject) => {
     window.addEventListener(
       "message",
       (event) => {
@@ -41,7 +45,6 @@ export async function launchIframe(
       false
     );
   });
-  return result;
 }
 
 export async function launchRedirect(launchUrl: string, redirectUrl: string) {
@@ -92,63 +95,73 @@ export async function launchPopup(
 }
 
 function showModal(launchUrl: string) {
-  removeModal();
+  let modal = document.getElementById("trinsic-ui");
 
-  const userAgents = detectUserAgents();
+  if (modal) {
+    // Modal already exists, update the iframe src
+    const iframe = modal.querySelector("iframe") as HTMLIFrameElement;
+    if (iframe) {
+      iframe.src = launchUrl;
+    }
+  } else {
+    // Create modal
+    const userAgents = detectUserAgents();
 
-  const modal = document.createElement("div");
-  modal.id = "trinsic-ui";
-  modal.ariaHidden = "true";
-  modal.className = "micromodal-slide";
+    modal = document.createElement("div");
+    modal.id = "trinsic-ui";
+    modal.ariaHidden = "true";
+    modal.className = "micromodal-slide";
 
-  const bgOverlay = document.createElement("div");
-  bgOverlay.tabIndex = -1;
-  // bgOverlay.setAttribute("data-micromodal-close", "true");
-  bgOverlay.className = "fixed inset-0 flex items-center justify-center modal__overlay";
+    const bgOverlay = document.createElement("div");
+    bgOverlay.tabIndex = -1;
+    bgOverlay.className =
+      "fixed inset-0 flex items-center justify-center modal__overlay";
 
-  const modalContainer = document.createElement("div");
-  //modalContainer.role = "dialog";
-  modalContainer.ariaModal = "true";
+    const modalContainer = document.createElement("div");
+    modalContainer.role = "dialog";
+    modalContainer.ariaModal = "true";
 
-  modalContainer.className = userAgents.isDesktop
-    ? "modal__container h-600px w-400px lock-bg shadow-lg"
-    : "modal__container h-full min-h-600px w-full";
+    modalContainer.className = userAgents.isDesktop
+      ? "modal__container h-600px w-400px lock-bg shadow-lg"
+      : "modal__container h-full min-h-600px w-full";
 
-  const iframe = document.createElement("iframe");
-  iframe.className = "h-full w-full bg-transparent";
-  iframe.allow =
-    "camera *; microphone *; display-capture *; publickey-credentials-get *; publickey-credentials-create *";
-  iframe.src = launchUrl;
+    const iframe = document.createElement("iframe");
+    iframe.className = "h-full w-full bg-transparent";
+    iframe.allow =
+      "camera *; microphone *; display-capture *; publickey-credentials-get *; publickey-credentials-create *";
+    iframe.src = launchUrl;
 
-  modalContainer.append(iframe);
-  bgOverlay.append(modalContainer);
-  modal.append(bgOverlay);
-  if (
-    document === null ||
-    document === undefined ||
-    document.body === null ||
-    document.body === undefined ||
-    document.body.classList === null ||
-    document.body.classList === undefined
-  ) {
-    throw new Error(
-      "document.body.classList is null or undefined. Make sure you run this code after your DOM has loaded. You can use the event listener 'DOMContentLoaded' to ensure this."
-    );
+    modalContainer.append(iframe);
+    bgOverlay.append(modalContainer);
+    modal.append(bgOverlay);
+
+    if (!document.body || !document.body.classList) {
+      throw new Error(
+        "document.body.classList is null or undefined. Ensure this code runs after the DOM has loaded."
+      );
+    }
+
+    document.body.append(modal);
+
+    // Initialize MicroModal only once
+    if (!isMicroModalInitialized) {
+      MicroModal.init();
+      isMicroModalInitialized = true;
+    }
   }
+
   document.body.classList.add("lock-bg");
-  document.body.append(modal);
+
+  // Show the modal
   MicroModal.show("trinsic-ui");
 }
 
 function hideModal() {
   try {
     MicroModal.close("trinsic-ui");
-  } catch (err) {}
+  } catch (err) {
+    console.error("Error closing modal:", err);
+  }
   document.body.classList.remove("lock-bg");
-  removeModal();
-}
-
-function removeModal() {
-  const trinsicui = document.getElementById("trinsic-ui");
-  trinsicui?.remove();
+  // Do not remove the modal from the DOM
 }

--- a/versions.json
+++ b/versions.json
@@ -12,5 +12,5 @@
   "flutterUIVersion": "1.0.0",
   "expoUIVersion": "1.0.0",
   "reactNativeUIVersion": "1.0.0",
-  "webUIVersion": "1.2.8"
+  "webUIVersion": "1.2.9"
 }


### PR DESCRIPTION
## Description

This PR resolves an issue where reopening the iframe modal multiple times results in the following error:

```
TypeError: Cannot read properties of null (reading 'removeEventListener').
```

The error was due to MicroModal attempting to interact with DOM elements that no longer existed after the modal was removed and recreated.

- Modified `showModal()` to check if the modal already exists.
- Adjusted `hideModal()` to only close the modal using `MicroModal.close("trinsic-ui")` without removing it from the DOM.
- Removed calls to `removeModal()`, preventing the deletion of modal elements.
- Made it so `MicroModal` is initialized only once
- Bumped `@trinsic/web-ui` to version `1.2.9` (PATCH updated)