### PR TITLE
Assign `launchUrl` to variable explicitly

### DIFF
--- a/ui-web/sdk/src/index.ts
+++ b/ui-web/sdk/src/index.ts
@@ -72,7 +72,12 @@ export async function launchPopup(
     throw new Error("Failed to open popup window");
   }
 
-  popup.location.href = await getLaunchUrl();
+  const launchUrl = await getLaunchUrl();
+  if(!launchUrl) {
+    throw new Error("Invalid launch URL " + launchUrl);
+  }
+
+  popup.location.href = launchUrl;
 
   var result = new Promise<TrinsicSessionResult>((resolve, reject) => {
     window?.addEventListener(

--- a/versions.json
+++ b/versions.json
@@ -12,5 +12,5 @@
   "flutterUIVersion": "1.0.0",
   "expoUIVersion": "1.0.0",
   "reactNativeUIVersion": "1.0.0",
-  "webUIVersion": "1.2.11"
+  "webUIVersion": "1.2.12"
 }


### PR DESCRIPTION
- Assign `launchUrl` to a `const` variable before setting it to `popup.location.href`.


Given the following code resulting from bundling our `launchPopup` method:

```js
function* (we) {
    let ve = x(),
        xe = window.open("https://api.trinsic.id/loading", "Trinsic", ve.isDesktop ? "width=600,height=900" : "width=" + window.innerWidth + ",height=" + window.innerHeight + ",top=0,left=0");
    if (!xe)
        throw new Error("Failed to open popup window");
    return xe.location.href = yield we(), new Promise((ze, lt) => {
        [...]
    })
}
```

We're observing that, on Safari, the window location never changes (`xe.location.href = yield we(), [...]`).

However, modifying the snippet like so:

```js
function* (we) {
    let ve = x(),
        xe = window.open("https://api.trinsic.id/loading", "Trinsic", ve.isDesktop ? "width=600,height=900" : "width=" + window.innerWidth + ",height=" + window.innerHeight + ",top=0,left=0");
    if (!xe)
        throw new Error("Failed to open popup window");
    const launchUrl = yield we();
    return xe.location.href = launchUrl, new Promise((ze, lt) => {
        [...]
    })
}
```

Results in everything working as expected.


While I am yet quite puzzled as to _why_ this is the case, this change is being made to attempt to force the transpiler/minimizer to produce similar code.