### PR TITLE
Fix `go`

### DIFF
--- a/api-go/build-sdk.ps1
+++ b/api-go/build-sdk.ps1
@@ -2,6 +2,7 @@ $additionalProperties = @{
     packageName                              = "trinsic_api"
     packageVersion                           = "[VERSION]"
     disallowAdditionalPropertiesIfNotPresent = "false"
+    enumClassPrefix                          = "true"
 }
 & "$PSScriptRoot/../helpers/generate-client.ps1" -language "go" -outputFolder "$PSScriptRoot/sdk-build" -additionalProperties $additionalProperties
 try {


### PR DESCRIPTION
- Fixes the `api-go` SDK generation
    - By default, the `go` generator creates Enum values as global constants. Since `IntegrationCapability` shares many enum names with `IntegrationLaunchMethod` and `CollectionMethod`, this created conflicts.
    - The fix is to instruct the `go` generator to prefix enum value names with the enum class name