### PR TITLE
Update Android SDK README and add Sample README

### DIFF
--- a/ui-android/README.md
+++ b/ui-android/README.md
@@ -8,6 +8,10 @@ This library must be paired with an [api library](https://github.com/trinsic-id/
 
 See the [Trinsic docs](https://docs.trinsic.id/docs/) for more detailed information on how to start integrating with our identity acceptance network.
 
+## Usage
+
+For usage instructions, see our [sample app](https://github.com/trinsic-id/sdk/tree/main/ui-android/samples/android_sample), which includes a README with detailed instructions on how to implement this library in your own app.
+
 ## Supported Use Cases
 
 ### Widget and Hosted Provider Sessions
@@ -68,6 +72,35 @@ First, choose a custom scheme to register against your app. This is necessary fo
 The custom scheme can be any valid URL scheme, but it **must be globally unique**. No other app -- including any of your own -- should register against the same scheme.
 
 An example of a good scheme is `acme-corp-shopping-app-trinsic-redirect`.
+
+### 2. Register and use the Custom Scheme with Trinsic
+
+#### a. Register the Custom Scheme with Trinsic
+After choosing a custom scheme, you must register it as a valid `redirectUrl` with Trinsic.
+This can be done on the Trinsic Dashboard.
+
+For example, if you chose `acme-corp-shopping-app-trinsic-redirect`, you would register the following URL with Trinsic:
+
+```
+acme-corp-shopping-app-trinsic-redirect:///*
+```
+
+**Things to note**:
+- The `*` at the end of the URL is a wildcard. It allows any path to be used in redirect URLs for this scheme.
+    - This library does not care about the redirect URL's path, only its scheme.
+- The triple slash (`///`) is required to construct a valid redirect URL with a custom scheme.
+    - The first two slashes are part of the scheme, and the third slash is the start of the path.
+
+#### b. Use the Custom Scheme with Trinsic
+After registering the custom scheme in the Dashboard, you may now use it in a `redirectUrl` when creating a Session.
+
+For example, given the custom scheme `acme-corp-shopping-app-trinsic-redirect`, the following is a valid `redirectUrl`:
+
+```
+acme-corp-shopping-app-trinsic-redirect:///callback
+```
+
+The path (`callback`) can be any valid path string.
 
 ### 2. Register the `CallbackActivity` in your app's `AndroidManifest.xml`
 

--- a/ui-android/samples/android_sample/README.md
+++ b/ui-android/samples/android_sample/README.md
@@ -1,0 +1,86 @@
+# Trinsic Android UI Library Sample
+
+## Documentation
+
+See the [Trinsic docs](https://docs.trinsic.id/docs/) for more detailed information on how to start integrating with our identity acceptance network.
+
+## How This Sample Works
+
+This sample implements the Trinsic Android UI Library to the extent necessary to demonstrate the basic functionality of the library.
+
+The relevant files for this sample are:
+- [[....]/MainActivity.java](https://github.com/trinsic-id/sdk/blob/main/ui-android/samples/android_sample/app/src/main/java/id/trinsic/android_sample/MainActivity.java)
+  - Implements the Trinsic UI library and handles the session result callback
+- [app/src/main/AndroidManifest.xml](https://github.com/trinsic-id/sdk/blob/main/ui-android/samples/android_sample/app/src/main/AndroidManifest.xml)
+  - Registers the custom URL scheme used to handle redirect responses
+- [settings.gradle.kts](https://github.com/trinsic-id/sdk/blob/main/ui-android/samples/android_sample/settings.gradle.kts)
+  - Adds jitpack as a Maven repository
+- [app/build.gradle.kts](https://github.com/trinsic-id/sdk/blob/main/ui-android/samples/android_sample/app/build.gradle.kts)
+  - Adds Trinsic Android SDK as a dependency
+
+This sample, by default, *does not hit Trinsic's API* or perform real verifications. Instead, it uses a Trinsic-provided test API which allows for quick and convenient testing of the library's functionality **without** needing a real API key or a backend of your own.
+
+Once you have implemented your own backend, this sample can easily be configured to perform real verifications simply by changing the `BACKEND_CREATE_SESSION_ENDPOINT` constant in `MainActivity.java` to point to your backend's endpoint.
+
+## Implementation Guide
+
+Below is a step-by-step guide to understanding both A) what this sample does and B) how to implement its functionality into your own app.
+
+### 1. Install and Configure the SDK
+
+Follow the installation steps described in the [README](https://github.com/trinsic-id/sdk/blob/main/ui-android/README.md), including:
+- Adding Jitpack to your Gradle repositories, if not present already
+- Including the `sdk-android-ui` dependency
+- Registering a custom URL scheme to handle redirect responses
+- Updating your `AndroidManifest.xml` to include the required activity declaration pointing to your custom scheme
+
+### 2. Prepare the Launch Activity
+
+In the Activity class which will initiate a Trinsic Session (e.g., your "verify your identity" Activity), you’ll need to:
+
+#### a. Declare a `TrinsicUI` variable
+
+Add this as a property of the class, typically at the top of the activity file:
+
+```java
+private TrinsicUI trinsicUI;
+```
+
+#### b. Instantiate `TrinsicUI` inside `onCreate()`
+
+You **must** call the constructor of `TrinsicUI` inside your `onCreate()` method every time it's invoked. This sets up an activity listener that the library uses to receive the Session result. **Do not** put this instantiation inside of an `if` statement.
+
+```java
+trinsicUI = new TrinsicUI(this, (result) -> {
+    if (result.getCanceled()) {
+        // User exited the verification session
+    } else if (!result.getSuccess()) {
+        // Verification failed
+    } else {
+        // Verification succeeded; result.getResultsAccessKey() contains your key
+    }
+});
+```
+
+This callback will be invoked once the user finishes a Session -- whether it succeeds, fails, or is cancelled.
+
+### 3. Obtain a Session Launch URL
+
+You’ll need to make a call to your backend to create a new Trinsic Session and retrieve its `launchUrl`.
+
+The sample app demonstrates this using a test-only endpoint (`https://api.trinsic.id/api/mobiletest/create-session`), but in production you'll want to use the [Trinsic API SDK](https://github.com/trinsic-id/sdk#api-libraries) on your backend to create a real Session and return the resulting `launchUrl` to your app.
+
+Example flow:
+1. User taps a “Verify Identity” button.
+2. Your frontend makes a request to your backend.
+3. Your backend calls Trinsic to create a session, and returns the `launchUrl` to the frontend.
+
+### 4. Launch the Session
+
+Once you’ve received the launch URL from your backend, invoke the Trinsic SDK:
+
+```java
+trinsicUI.LaunchSession(MainActivity.this, launchUrl);
+```
+
+This will launch an Android Custom Tab and guide the user through the identity verification flow. When complete, your previously defined callback will be triggered with the results.

--- a/ui-android/samples/android_sample/README.md
+++ b/ui-android/samples/android_sample/README.md
@@ -6,6 +6,11 @@ See the [Trinsic docs](https://docs.trinsic.id/docs/) for more detailed informat
 
 ## How This Sample Works
 
+> [!IMPORTANT]  
+> This sample, by default, *does not hit Trinsic's API* or perform real verifications. Instead, it uses a Trinsic-provided test API which allows for quick and convenient testing of the library's functionality **without** needing a real API key or a backend of your own.
+> 
+> Once you have implemented your own backend, this sample can easily be configured to perform real verifications simply by changing the `BACKEND_CREATE_SESSION_ENDPOINT` constant in `MainActivity.java` to point to your backend's endpoint.
+
 This sample implements the Trinsic Android UI Library to the extent necessary to demonstrate the basic functionality of the library.
 
 The relevant files for this sample are:
@@ -17,10 +22,6 @@ The relevant files for this sample are:
   - Adds jitpack as a Maven repository
 - [app/build.gradle.kts](https://github.com/trinsic-id/sdk/blob/main/ui-android/samples/android_sample/app/build.gradle.kts)
   - Adds Trinsic Android SDK as a dependency
-
-This sample, by default, *does not hit Trinsic's API* or perform real verifications. Instead, it uses a Trinsic-provided test API which allows for quick and convenient testing of the library's functionality **without** needing a real API key or a backend of your own.
-
-Once you have implemented your own backend, this sample can easily be configured to perform real verifications simply by changing the `BACKEND_CREATE_SESSION_ENDPOINT` constant in `MainActivity.java` to point to your backend's endpoint.
 
 ## Implementation Guide
 


### PR DESCRIPTION
- Updates Android SDK README
    - Adds section on registering & using custom scheme with Trinsic
    - Adds `Usage` section pointing to Sample README
        - Encourages people to view the Sample and keeps primary README dedicated to the true nuances of this library
- Adds Android SDK _Sample_ README
    - Explains the mechanics behind the Sample, as well as an implementation guide for the library as a whole