### PR TITLE
fix python project name to comply with PEP 625

### DIFF
--- a/api-python/build-sdk.ps1
+++ b/api-python/build-sdk.ps1
@@ -2,7 +2,7 @@ $additionalProperties = @{
     packageName    = "trinsic_api"
     packageVersion = "[VERSION]"
     packageUrl     = "https://trinsic.id"
-    projectName    = "Trinsic-Api"
+    projectName    = "trinsic_api"
 }
 & "$PSScriptRoot/../helpers/generate-client.ps1" -language "python" -outputFolder "$PSScriptRoot/sdk" -additionalProperties $additionalProperties
 


### PR DESCRIPTION
> In distribution names, any run of -_. characters (HYPHEN-MINUS, LOW LINE and FULL STOP) should be replaced with _ (LOW LINE), and uppercase characters should be replaced with corresponding lowercase ones. This is equivalent to regular [name normalization](https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization) followed by replacing - with _. Tools consuming wheels must be prepared to accept . (FULL STOP) and uppercase letters, however, as these were allowed by an earlier version of this specification.