### PR TITLE
Improve handling/detection of DC API support across browsers

### DIFF
--- a/ui-web/sdk/src/detectUserAgents.ts
+++ b/ui-web/sdk/src/detectUserAgents.ts
@@ -8,6 +8,7 @@ export interface UserAgents {
   isChrome: boolean;
   isSafari: boolean;
   isSSR: boolean;
+  supportsDigitalCredentialsApi: boolean;
 }
 export const detectUserAgents = (): UserAgents => {
   const userAgent = navigator.userAgent;
@@ -24,6 +25,7 @@ export const detectUserAgents = (): UserAgents => {
     return !!anyWindow.chrome;
   };
   const isChrome = (): boolean => Boolean(isChromium() && !isEdge() && !isOpera());
+  const supportsDigitalCredentialsApi = (): boolean => !!navigator.credentials && !!navigator.credentials.get && typeof (window as any).DigitalCredential !== "undefined";
 
   const isMobile = (): boolean =>
     Boolean(isAndroid() || isIos() || isOpera() || isWindowsMobile());
@@ -38,5 +40,6 @@ export const detectUserAgents = (): UserAgents => {
     isChromium: isChromium(),
     isChrome: Boolean(isChromium() && !isEdge() && !isOpera()),
     isSafari: isSafari(),
+    supportsDigitalCredentialsApi: supportsDigitalCredentialsApi()
   };
 };

--- a/ui-web/sdk/src/mdlExchange.ts
+++ b/ui-web/sdk/src/mdlExchange.ts
@@ -89,9 +89,9 @@ export async function performMdlExchange(
   // Perform the DC API exchange
   const response = await navigator.credentials.get(req);
 
-  // If a single credential cannot be unambiguously obtained, the promise resolves with null.
+  // `null` is returned by Chrome browsers which don't support the DC API
   if (response === null || response === undefined) {
-    throw new Error("Your wallet app was unable to find a suitable document.");
+    throw new Error("Your browser does not support this feature");
   }
 
   // We have to massage the response a bit to make it serializable.
@@ -120,17 +120,11 @@ export async function performMdlExchange(
  *
  * This can help determine which wallet options to display to the user.
  *
- * NOTE: This is a simple heuristic and is likely not 100% accurate at this time.
- *
  * @returns Whether the user is on an Apple Wallet-supporting browser
  */
 export function isUserOnEligibleAppleWalletBrowser(): boolean {
-  if (!navigator.credentials || !navigator.credentials.get) {
-    return false;
-  }
-
   const userAgents = detectUserAgents();
-  return (
+  return userAgents.supportsDigitalCredentialsApi && (
     userAgents.isIos ||
     userAgents.isSafari ||
     userAgents.isMacOs ||
@@ -143,15 +137,9 @@ export function isUserOnEligibleAppleWalletBrowser(): boolean {
  *
  * This can help determine which wallet options to display to the user.
  *
- * NOTE: This is a simple heuristic and is likely not 100% accurate at this time.
- *
  * @returns Whether the user is on a Google Wallet-supporting browser
  */
 export function isUserOnEligibleGoogleWalletBrowser(): boolean {
-  if (!navigator.credentials || !navigator.credentials.get) {
-    return false;
-  }
-
   const userAgents = detectUserAgents();
-  return userAgents.isAndroid && userAgents.isChrome;
+  return userAgents.supportsDigitalCredentialsApi && userAgents.isAndroid && userAgents.isChrome;
 }

--- a/versions.json
+++ b/versions.json
@@ -11,5 +11,5 @@
   "androidUIVersion": "2.1.0-alpha1",
   "flutterUIVersion": "2.0.0",
   "expoUIVersion": "2.0.1",
-  "webUIVersion": "3.0.2"
+  "webUIVersion": "3.0.3"
 }


### PR DESCRIPTION
- Adds detection of the `DigitalCredential` feature to assist in determining whether the user's browser is eligible for Apple / Google Wallet
- Improves inaccurate error message when `navigator.credentials.get()` returns `null`