### PR TITLE
Bump ui-swift to 2.1.1 with cancel() API

### DIFF
--- a/ui-swift/samples/iOS/iOS/ContentView.swift
+++ b/ui-swift/samples/iOS/iOS/ContentView.swift
@@ -13,6 +13,7 @@ let startUrl = "https://api.trinsic.id/api/mobiletest/create-session?redirectSch
 
 struct ContentView: View {
     @State private var isButtonEnabled = false
+    @State private var autoCancelAfter10s = false
     @State private var redirectedURL: URL?
     // Pick between our default one presentationContextProvider
     let trinsicUI = TrinsicUI()
@@ -20,11 +21,12 @@ struct ContentView: View {
     //let trinsicUI = TrinsicUI(presentationContextProvider: CustomContextProvider.init())
 
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
             Text("Hello, world!")
+            Toggle("Auto-cancel after 10s", isOn: $autoCancelAfter10s)
             Button(action: {
                 Task {
                     await handleButtonClick()
@@ -49,13 +51,24 @@ struct ContentView: View {
         }
         .padding()
     }
-    
+
     func handleButtonClick() async {
         do {
             if let url = redirectedURL {
-                
+
                 print("Button clicked, opening: \(url)")
-                
+
+                var cancelTask: Task<Void, Never>?
+                if autoCancelAfter10s {
+                    cancelTask = Task {
+                        try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
+                        guard !Task.isCancelled else { return }
+                        print("Auto-cancel firing after 10s")
+                        trinsicUI.cancel()
+                    }
+                }
+                defer { cancelTask?.cancel() }
+
                 let result = try await trinsicUI.launchSession(launchUrl: url.absoluteString, callbackUrlScheme: sampleCallbackUrlScheme)
                 print("Success \(result.success)")
                 print("Canceled \(result.canceled)")
@@ -66,7 +79,7 @@ struct ContentView: View {
         catch {
             print("Error: \(error)")
         }
-        
+
     }
 }
 

--- a/versions.json
+++ b/versions.json
@@ -7,7 +7,7 @@
   "pythonPatchVersion": "0",
   "phpPatchVersion": "0",
   "rubyPatchVersion": "0",
-  "swiftUIVersion": "2.1.0-alpha4",
+  "swiftUIVersion": "2.1.1",
   "androidUIVersion": "2.1.0",
   "flutterUIVersion": "2.0.0",
   "expoUIVersion": "2.0.1",


### PR DESCRIPTION
Adds TrinsicUI.cancel() (sdk-swift-ui#7) and a sample-side demonstration with an auto-cancel toggle.