### PR TITLE
Optional pollWhilePopupOpen

### DIFF
--- a/ui-web/README.md
+++ b/ui-web/README.md
@@ -55,7 +55,8 @@ If you are using this library to launch Trinsic sessions from within an iFrame, 
       - Therefore, in certain circumstances, it may be impossible for the popup window to send the finalization signal to the parent window.
     - As a consequence, you **must** provide a value for `pollingFunction` when awaiting a popup's completion.
         - This function should hit your backend and query the status of the session.
-        - The library will only call `pollingFunction` if it detects that the browser has closed off cross-window communication with the popup.
+        - By default, the library only calls `pollingFunction` if it detects that the browser has closed off cross-window communication with the popup.
+        - Set `pollWhilePopupOpen: true` to poll continuously (including while the popup still appears open). This is useful in case the popup never closed but the verification completed elsewhere.
 
 ## Usage
 ### Redirect Query Parameters

--- a/ui-web/sdk/src/TrinsicPopup.ts
+++ b/ui-web/sdk/src/TrinsicPopup.ts
@@ -186,8 +186,11 @@ export class TrinsicPopup {
                         return;
                     }
 
-                    // Don't poll if we still have a connection to the popup -- no need, since polling is a backup mechanism
-                    if (!this.isMaybeClosed) {
+                    // By default, polling is a backup when the popup connection is lost.
+                    // With pollWhilePopupOpen, poll for the life of waitForCompletion(),
+                    // in case the popup never closed but the verification completed
+                    // elsewhere.
+                    if (!options.pollWhilePopupOpen && !this.isMaybeClosed) {
                         return;
                     }
 
@@ -303,9 +306,19 @@ export interface WaitForResultsOptions {
      * 
      * This is necessary because certain circumstances could cause cross-window messaging to be blocked by the browser when running inside a cross-origin iFrame.
      * 
-     * This function is not called unless the library detects that the browser has closed off cross-window communication with the popup.
+     * By default this function is not called unless the library detects that the browser has closed off cross-window communication with the popup, but
+     * you can set pollWhilePopupOpen to true to poll for the lifetime of waitForCompletion(), including while the popup still appears open.
      */
     pollingFunction?: () => Promise<boolean>;
+
+    /**
+     * If true, call pollingFunction on an interval for the lifetime of waitForCompletion(), even while the popup still appears open.
+     * 
+     * This option is useful as a fallback in case the popup never closed but the verification completed elsewhere.
+     * 
+     * Default value: false (only poll after the popup connection appears closed).
+     */
+    pollWhilePopupOpen?: boolean;
 
     /**
      * A function which is called when an error occurs in the polling function.


### PR DESCRIPTION
Added `pollWhilePopupOpen`, an optional behavior. By default, the web UI SDK only calls `pollingFunction` if it detects the browser has lost communication with the popup. However, it is possible that a verification has been completed but the popup was never closed.

This will run the polling function all the time, even when the popup is open.