### PR TITLE
Release Android SDK version `2.1.1`

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,7 +8,7 @@
   "phpPatchVersion": "0",
   "rubyPatchVersion": "0",
   "swiftUIVersion": "2.1.1",
-  "androidUIVersion": "2.1.0",
+  "androidUIVersion": "2.1.1",
   "flutterUIVersion": "2.0.0",
   "expoUIVersion": "2.0.1",
   "webUIVersion": "3.0.3"


### PR DESCRIPTION
- Bumps Android SDK to `2.1.1`
    - Fixes improper handling of Activity lifecycle resumption by `InvokeActivity`