### PR TITLE
Update Python sample to 3.2.1

### DIFF
--- a/api-python/samples/server/direct.py
+++ b/api-python/samples/server/direct.py
@@ -2,11 +2,10 @@ from fastapi import Request, APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from trinsic_api.api.sessions_api import SessionsApi, CreateDirectProviderSessionRequest, GetSessionResultRequest, RefreshStepContentRequest
 import os
-from urllib.parse import urlencode
-from datetime import datetime, timezone
 from fastapi.responses import RedirectResponse
 import json
 from datetime import date, datetime
+from uuid import UUID
 
 directRouter = APIRouter()
 
@@ -30,6 +29,8 @@ async def launch(request: Request, provider_id: str, sessions_api: SessionsApi =
 
 def json_serial(obj):
     """JSON serializer for objects not serializable by default."""
+    if isinstance(obj, UUID):
+        return str(obj)
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
     raise TypeError(f"Type {type(obj)} not serializable")

--- a/api-python/samples/server/hosted.py
+++ b/api-python/samples/server/hosted.py
@@ -3,6 +3,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from trinsic_api.api.sessions_api import SessionsApi, CreateHostedProviderSessionRequest
 from fastapi.responses import RedirectResponse
+from datetime import date, datetime
+from uuid import UUID
 import os
 import json
 
@@ -21,6 +23,8 @@ async def launch(request: Request, provider_id: str, sessions_api: SessionsApi =
     return JSONResponse(content=json.loads(json.dumps(result.to_dict(), default=json_serial)))
 def json_serial(obj):
     """JSON serializer for objects not serializable by default."""
+    if isinstance(obj, UUID):
+        return str(obj)
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
     raise TypeError(f"Type {type(obj)} not serializable")

--- a/api-python/samples/server/requirements.txt
+++ b/api-python/samples/server/requirements.txt
@@ -1,4 +1,4 @@
-trinsic_api==3.0.1
+trinsic_api==3.2.1
 fastapi
 pydantic
 python-dotenv


### PR DESCRIPTION
`sessionId` on create-hosted and create-direct responses is now a UUID, which `json.dumps` cannot serialize. Added UUID serialization to the existing serializer (stringify the UUIDs). Also added missing `datetime` imports in `hosted.py`.